### PR TITLE
Add support for NTFY notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 __pycache__/
 .venv
+config.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 __pycache__/
+.venv

--- a/50check.py
+++ b/50check.py
@@ -19,17 +19,21 @@ if platform.system() == 'Windows':
     import winsound
 
 # Import configuration
-from config import (
-    PRODUCT_CONFIG_CARDS,
-    STATUS_UPDATES,
-    TELEGRAM_CONFIG,
-    NTFY_CONFIG,
-    NOTIFICATION_CONFIG,
-    API_CONFIG,
-    SKU_CHECK_API_CONFIG,
-    LOCALE_CONFIG,
-    SKU_CHECK_CONFIG
-)
+try:
+    from config import (
+        PRODUCT_CONFIG_CARDS,
+        STATUS_UPDATES,
+        TELEGRAM_CONFIG,
+        NTFY_CONFIG,
+        NOTIFICATION_CONFIG,
+        API_CONFIG,
+        SKU_CHECK_API_CONFIG,
+        LOCALE_CONFIG,
+        SKU_CHECK_CONFIG
+    )
+except ModuleNotFoundError:
+    print("config.py DOES NOT EXIST. Rename example_config.py to config.py to begin.")
+    sys.exit(1)
 
 # Get enabled Cards based on configuration
 AVAILABLE_CARDS = {card: config["enabled"]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The script supports checking of all currently known 50 series Founders Edition, 
 1. **Save below files from repo**:
    ```bash
    50check.py
-   config.py
+   example_config.py
    stockconfig.py
    locales.txt
    ```
@@ -64,7 +64,11 @@ The script supports checking of all currently known 50 series Founders Edition, 
    ```
 
 3. **Configure the script**:
-   - Edit `config.py` to your preference. If you want to use the Telegram notifications, ensure you add your Telegram bot token and chat ID.
+   - Copy `example_config.py` to `config.py`:
+   ```bash
+     cp config.example.py config.py
+   ```
+   - Edit `config.py` to your preference. Refer the configuration section as well as documentation in `example_config.py` on configuration options.
 
 ## Installation - METHOD 2
 
@@ -84,7 +88,7 @@ The script supports checking of all currently known 50 series Founders Edition, 
      ```bash
      cp config.example.py config.py
      ```
-   - Edit `config.py` to your preference. If you want to use the Telegram notifications, ensure you add your Telegram bot token and chat ID.
+   - Edit `config.py` to your preference. Refer the configuration section as well as documentation in `example_config.py` on configuration options.
 
 ---
 
@@ -97,6 +101,7 @@ The `config.py` file contains all the configuration options. Here are the key se
 - **`TELEGRAM_CONFIG`**: All Telegram features are turned off by default. Configure your Telegram bot token and chat ID ([Setup guide](https://gist.github.com/nafiesl/4ad622f344cd1dc3bb1ecbe468ff9f8a)).
 - **`API_CONFIG`**: Configure the NVIDIA API URL and parameters. (DO NOT CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING).
 - **`SKU_CHECK_CONFIG`**: Configure the interval for refreshing SKUs (default: 3600 seconds).
+- **`NTFY_CONFIG`**: Configure notifications via NTFY. Turned off by default. At minimum, set a topic to publish to. Refer to ([NTFY Docs](https://docs.ntfy.sh/)) for more information.
 
 ---
 
@@ -203,6 +208,12 @@ When stock changes are detected, the script sends a Telegram message like this:
 💰 Price: £1,939.00
 🔗 Link: https://www.nvidia.com/en-gb/geforce/graphics-cards/50-series/rtx-5090/
 ```
+
+### NTFY Notifications
+
+When stock changes are detected, the script sends a NTFY message to your topic similar to Telegram. 
+
+> The script only sends stock updates to your NTFY topic, status and startup messages will not be sent.
 
 ### Sound Notifications
 

--- a/config.py
+++ b/config.py
@@ -59,6 +59,16 @@ TELEGRAM_CONFIG = {
 }
 
 # =================================
+# NTFY Configuration
+# =================================
+NTFY_CONFIG = {
+    "enabled": False,           # Enable stock notifications via NTFY
+    "topic": "XXXXXXX",         # Topic to publish to
+    "access_token": "XXXXXXX",   # Access token (auth)
+    "url": "https://ntfy.sh"    # Change to use a self-hosted NTFY instance
+}
+
+# =================================
 # API Configuration
 # LEAVE THIS SECTION ALONE IF YOU DON'T KNOW WHAT THIS MEANS.
 # =================================
@@ -66,7 +76,7 @@ API_CONFIG = {
     "url": "https://api.store.nvidia.com/partner/v1/feinventory",
     "params": {
         "locale": LOCALE_CONFIG["locale"],
-        "cooldown": 120,       # Seconds to wait after finding stock before resuming checks (60 seconds default)
+        "cooldown": 120,       # Seconds to wait after finding stock before resuming checks (120 seconds default)
         "check_interval": 10   # Seconds between checks (10secs default)
     },
     "headers": {

--- a/example_config.py
+++ b/example_config.py
@@ -64,7 +64,7 @@ TELEGRAM_CONFIG = {
 NTFY_CONFIG = {
     "enabled": False,           # Enable stock notifications via NTFY
     "topic": "XXXXXXX",         # Topic to publish to
-    "access_token": "XXXXXXX",   # Access token (auth)
+    "access_token": "",         # Auth access token (Optional)
     "url": "https://ntfy.sh"    # Change to use a self-hosted NTFY instance
 }
 

--- a/stockconfig.py
+++ b/stockconfig.py
@@ -3,14 +3,18 @@ import argparse
 import json
 from typing import Dict, List, Tuple
 import re
+import sys
 
+try:
 # Import configuration from config.py
-from config import (
-    API_CONFIG,
-    SKU_CHECK_API_CONFIG,
-    LOCALE_CONFIG,
-    PRODUCT_CONFIG_CARDS
-)
+    from config import (
+        API_CONFIG,
+        SKU_CHECK_API_CONFIG,
+    )
+except ModuleNotFoundError:
+    print("config.py DOES NOT EXIST. Rename example_config.py to config.py to begin.")
+    sys.exit(1)
+
 
 def load_locales() -> List[Tuple[str, str, str]]:
     """


### PR DESCRIPTION
Hi,

I don't use telegram and would like to recieve notifications on my phone and additional PCs. I propose adding support for [binwiederhier/ntfy](https://github.com/binwiederhier/ntfy), an open source notification server. 

> ntfy lets you send push notifications to your phone or desktop via scripts from any computer, using simple HTTP PUT or POST requests.

A [similar tool](https://github.com/jef/streetmerchant) supports this and I've had a positive experience using it before.

My changes include an implementation for this feature as well as some slight refactoring to notification dispatching which makes it more extendable. 

### Additional contribution
While working on this I had to keep two copies of `config.py` which were both tracked - one for the example and the actual config I'm using. To simplify development I propose that we ignore the config file and instead ship `example_config.py`. This also makes it harder to commit your own private key, but adds an additional setup step. 

Looking forward to hearing your thoughts on this.


